### PR TITLE
Fix scroll starting position on display page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,18 +15,19 @@ onMounted(async () => {
   await i18nextPromise;
   document.body.classList.add("dark:bg-theme-gray");
   document.documentElement.lang = i18next.resolvedLanguage ?? "en";
+  window.history.scrollRestoration = "manual"
 });
 </script>
 
 <template>
   <TopBar />
-  <div :class="{'container mx-auto': state.useContainer}">
+  <div :class="{ 'container mx-auto': state.useContainer }">
     <InstallPrompt />
     <div class="mt-16 mx-4 mb-10 dark:text-white">
       <router-view v-slot="{ Component }">
         <transition mode="out-in">
-          <component :is="Component"></component>
-        </transition>
+            <component :is="Component"></component>
+          </transition>
       </router-view>
     </div>
   </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,15 @@ registerSW({ immediate: true, onOfflineReady() { } });
 const router = createRouter({
     history: createWebHashHistory(),
     routes,
+    scrollBehavior(to, from, savedPosition) {
+        if (to.name === "recipe-id") {
+            return new Promise((resolve) => {
+                setTimeout(() => {
+                    resolve({ left: 0, top: 0 })
+                }, 100)
+            })
+        }
+    }
 });
 
 const app = createApp(Suspenser);

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -152,10 +152,9 @@ onMounted(async () => {
 
   window.addEventListener("scroll", onScrol)
 
-  await nextTick();
   if (state.indexScrollY > 0) {
-    window.scrollTo(0, state.indexScrollY);
-  }
+      window.scrollTo(0, state.indexScrollY);
+    }
 });
 
 onBeforeUnmount(() => {

--- a/src/pages/recipe/[id]/index.vue
+++ b/src/pages/recipe/[id]/index.vue
@@ -129,8 +129,6 @@ onMounted(async () => {
     item.value = recipe;
   }
 
-  await nextTick();
-  window.scrollTo(0, 0)
 });
 
 function setupMenuOptions() {

--- a/src/pages/recipe/[id]/index.vue
+++ b/src/pages/recipe/[id]/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed, nextTick } from "vue";
+import { ref, onMounted, computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import {
   getRecipe,

--- a/src/pages/recipe/[id]/index.vue
+++ b/src/pages/recipe/[id]/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from "vue";
+import { ref, onMounted, computed, nextTick } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import {
   getRecipe,
@@ -128,6 +128,9 @@ onMounted(async () => {
 
     item.value = recipe;
   }
+
+  await nextTick();
+  window.scrollTo(0, 0)
 });
 
 function setupMenuOptions() {


### PR DESCRIPTION
This pull request primarily focuses on improving the user experience on the recipe page of the application. The changes include importing the `nextTick` method from Vue and using it to scroll the window to the top after the recipe data has been loaded.

Here are the key changes:

* `src/pages/recipe/[id]/index.vue`: Imported the `nextTick` method from Vue's API to ensure that certain operations are performed after the next DOM update cycle. ([src/pages/recipe/[id]/index.vueL2-R2](diffhunk://#diff-e66b4651b56d6d50a747bb706db735545478b27ec3d9a9f13bf9587974cd1142L2-R2))
* `src/pages/recipe/[id]/index.vue`: Added a call to `nextTick` followed by `window.scrollTo(0, 0)` in the `onMounted` hook. This ensures that the window is scrolled to the top after the recipe data has been loaded, providing a better user experience. ([src/pages/recipe/[id]/index.vueR131-R133](diffhunk://#diff-e66b4651b56d6d50a747bb706db735545478b27ec3d9a9f13bf9587974cd1142R131-R133))

Fixes #292 