### PR TITLE
Add video thumbnails to the reciple display pages

### DIFF
--- a/.github/workflows/azure-static-web-apps-delightful-flower-0c3edd710.yml
+++ b/.github/workflows/azure-static-web-apps-delightful-flower-0c3edd710.yml
@@ -46,23 +46,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-    
-      - name: Determine Version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-
-      - name: Set Version number in .env
-        uses: datamonsters/replace-action@v2
-        with:
-          files: '.env'
-          replacements: 'DEV=${{ steps.gitversion.outputs.majorMinorPatch }}'
-
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,9 +1,0 @@
-mode: Mainline
-branches: {}
-ignore:
-  sha: []
-major-version-bump-message: '^(breaking|major):'
-minor-version-bump-message: '^(feature|minor):'
-patch-version-bump-message: '^(fix|patch):'
-no-bump-message: '^(none|skip):'
-merge-message-formats: {}

--- a/src/components/RecipeCard.vue
+++ b/src/components/RecipeCard.vue
@@ -24,7 +24,8 @@ const emit = defineEmits<{
           cursor-pointer
         ">
         <div style="height: calc(100% - 0.5rem)" class="-mx-5 -mt-5 overflow-hidden">
-            <img alt="Recipe" v-if="props.imageAvailable" :src="props.image" class="object-contain m-auto" />
+            <img alt="Recipe" v-if="props.imageAvailable" :src="props.image" class="object-contain m-auto"
+                data-testid="recipe-image" />
             <div v-else class="bg-theme-primary h-full grid place-items-center">
                 <svg class="h-16 w-16 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                     stroke-linecap="round" stroke-linejoin="round">
@@ -38,7 +39,7 @@ const emit = defineEmits<{
             <div class="truncate grow pe-2">
                 <span data-testid="recipe-title" class="text-ellipsis text-black dark:text-white text-lg">{{
                     props.title
-                }}</span>
+                    }}</span>
             </div>
             <div class="my-auto" v-if="props.rating > 0">
                 <span data-testid="recipe-score" class="text-black dark:text-white">⭐{{

--- a/src/components/RecipeList.vue
+++ b/src/components/RecipeList.vue
@@ -3,7 +3,7 @@ import { ref, onMounted, watch, nextTick, onBeforeUnmount } from "vue";
 import { useRouter } from "vue-router";
 import { useTranslation } from "i18next-vue";
 import { useState } from "../services/store";
-import { getRecipesByCategory, getRecipeMedia, initialize, saveSetting, getSetting, getRecipes } from "../services/dataService";
+import { getRecipesByCategory, getRecipeMediaUrl, initialize, saveSetting, getSetting, getRecipes } from "../services/dataService";
 import { RecipeViewModel } from "../pages/recipe/recipeViewModel";
 import debounce from "lodash.debounce";
 import { TransitionRoot, Menu, MenuButton, MenuItems, MenuItem } from "@headlessui/vue";
@@ -162,8 +162,7 @@ async function loadCategory() {
   }
 
   for (const recipe of allRecipes) {
-    const item = await getRecipeMedia(recipe.id || 0);
-    recipe.image = (item && item.url) || undefined;
+    recipe.image = await getRecipeMediaUrl(recipe.id || 0);
     recipe.imageAvailable = recipe.image ? true : false;
   }
 

--- a/src/helpers/videoHelpers.ts
+++ b/src/helpers/videoHelpers.ts
@@ -1,3 +1,4 @@
+
 export function isVideoUrlSupported(url: string) {
     return !url
         || url.startsWith("https://www.youtube.com/")
@@ -5,7 +6,19 @@ export function isVideoUrlSupported(url: string) {
         || url.startsWith("https://youtu.be/");
 }
 
+export function getThumbnail(url: string) {
+    const id = getVideoId(url);
+
+    return `https://img.youtube.com/vi/${id}/0.jpg`;
+}
+
 export function prepareUrlForEmbed(url: string) {
+    const id = getVideoId(url);
+
+    return `https://www.youtube.com/embed/${id}`;
+}
+
+function getVideoId(url: string) {
     const regexp = /watch\?v=([\w-]*)|embed\/([\w-]*)|youtu\.be\/([\w-]*)/;
 
     // get the capture group from regexp
@@ -13,11 +26,9 @@ export function prepareUrlForEmbed(url: string) {
     if (!match) {
         return "";
     }
-    
+
     // there are 3 possible matches in the regex
     // the code below checks for all of them 
     // and returns the first one that is not null
-    const id = match[1] || match[2] || match[3];
-
-    return `https://www.youtube.com/embed/${id}`;
+    return match[1] || match[2] || match[3];
 }

--- a/src/pages/recipe/[id]/print.vue
+++ b/src/pages/recipe/[id]/print.vue
@@ -3,7 +3,7 @@ import { ref, onMounted, computed } from "vue";
 import { useRoute, onBeforeRouteLeave } from "vue-router";
 import {
   getRecipe,
-  getRecipeMedia,
+  getRecipeMediaUrl,
   getSetting
 } from "../../../services/dataService";
 import { useTranslation } from "i18next-vue";
@@ -57,14 +57,14 @@ onMounted(async () => {
   ];
 
   const recipe = (await getRecipe(id.value)) as RecipeViewModel;
-  const image = await getRecipeMedia(id.value);
+  const image = await getRecipeMediaUrl(id.value);
   const defaultTimeSetting = await getSetting("StepsInterval", "5");
 
   if (recipe) {
     state.title = recipe.title;
 
     item.value = recipe;
-    item.value.image = image?.url;
+    item.value.image = image;
     displayTime.value = getRecipeDisplayTime(recipe, parseInt(defaultTimeSetting));
   }
 

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -3,6 +3,7 @@ import { BackupModel, RecipeBackupModel } from "../pages/recipe/backupModel"
 import { Recipe, RecipeImage, RecipeMedia, RecipeNutrition } from "./recipe";
 import { Setting } from "./setting";
 import { Category } from "./category";
+import { getThumbnail } from "../helpers/videoHelpers";
 
 class RecipeDatabase extends Dexie {
     public recipes!: Table<Recipe, number>;
@@ -103,10 +104,19 @@ export async function getRecipeMediaList(id: number): Promise<RecipeMedia[]> {
 }
 
 export async function getRecipeMedia(id: number): Promise<RecipeMedia | undefined> {
-    const result = await db.recipeMedia
+    return await db.recipeMedia
         .where("recipeId").equals(id)
-        .and(item => item.type == "img")
         .first();
+}
+
+export async function getRecipeMediaUrl(id: number): Promise<string | undefined> {
+    const media = await getRecipeMedia(id);
+
+    let result = media?.url;
+    if (media?.type == "vid")
+    {
+        result = getThumbnail(media.url);
+    }
 
     return result;
 }

--- a/tests/category-recipes.spec.ts
+++ b/tests/category-recipes.spec.ts
@@ -31,6 +31,7 @@ test('title is Category 1', async ({ page }) => {
 test('open recipe', async ({ page }) => {
   await createRecipe(page, 2, "recipe", 1, ["1 cup flour"], ["Preheat oven to 350 F"], false, "Category 1");
   await goToCategory(page, "Category 1");
+  await page.waitForTimeout(200);
   await page.getByTestId('recipe-title').first().click();
   await page.waitForTimeout(200);
   await expect(page).toHaveURL(/.*\/recipe\/2/);

--- a/tests/category-recipes.spec.ts
+++ b/tests/category-recipes.spec.ts
@@ -18,7 +18,7 @@ test.beforeEach(async ({ page }) => {
 async function goToCategory(page: Page, category: string) {
   await page.goto('/');
   await page.getByText(category).click();
-  await page.waitForTimeout(200);
+  await page.waitForTimeout(500);
 }
 
 test('title is Category 1', async ({ page }) => {
@@ -31,7 +31,6 @@ test('title is Category 1', async ({ page }) => {
 test('open recipe', async ({ page }) => {
   await createRecipe(page, 2, "recipe", 1, ["1 cup flour"], ["Preheat oven to 350 F"], false, "Category 1");
   await goToCategory(page, "Category 1");
-  await page.waitForTimeout(200);
   await page.getByTestId('recipe-title').first().click();
   await page.waitForTimeout(200);
   await expect(page).toHaveURL(/.*\/recipe\/2/);

--- a/tests/edit.spec.ts
+++ b/tests/edit.spec.ts
@@ -111,6 +111,8 @@ test('video media shows thumbnail', async ({ page, browserName, isMobile }) => {
   await expect(page.locator("iframe"))
     .toHaveAttribute("src", "https://www.youtube.com/embed/0YY7K7Xa5rE");
 
+  await page.getByTestId("topbar-single-button").click();
+
   await page.goto('/');
   await expect(page.getByTestId('recipe-image')).toHaveAttribute("src", "https://img.youtube.com/vi/0YY7K7Xa5rE/0.jpg")
 });

--- a/tests/edit.spec.ts
+++ b/tests/edit.spec.ts
@@ -99,6 +99,22 @@ test('add video', async ({ page, browserName, isMobile }) => {
     .toHaveAttribute("src", "https://www.youtube.com/embed/0YY7K7Xa5rE");
 });
 
+test('video media shows thumbnail', async ({ page, browserName, isMobile }) => {
+  await page.goto('/');
+  await page.getByText('Sourdough Bread').first().click();
+  await page.getByTestId('edit-button').click();
+  await page.getByTestId('remove-image-button').click();
+  await page.getByTestId('add-video-button').click();
+  await page.getByTestId('add-video-url').fill("https://www.youtube.com/watch?v=0YY7K7Xa5rE");
+  await page.getByRole("button").getByText("OK").click();
+
+  await expect(page.locator("iframe"))
+    .toHaveAttribute("src", "https://www.youtube.com/embed/0YY7K7Xa5rE");
+
+  await page.goto('/');
+  await expect(page.getByTestId('recipe-image')).toHaveAttribute("src", "https://img.youtube.com/vi/0YY7K7Xa5rE/0.jpg")
+});
+
 test('remove media', async ({ page }) => {
   await page.goto('/');
   await page.getByText('Sourdough Bread').first().click();


### PR DESCRIPTION
This pull request includes multiple changes to the codebase, focusing on removing GitVersion setup, updating the data service, and adding new functionalities for handling video URLs. The most important changes are listed below:

### Removal of GitVersion Setup:

* [`.github/workflows/azure-static-web-apps-delightful-flower-0c3edd710.yml`](diffhunk://#diff-459effd35594ea2cb983111583eb7eefebb5acfc1ebf836ae3c2e5032f333185L49-L65): Removed steps for installing and determining GitVersion, as well as setting the version number in `.env`.
* [`GitVersion.yml`](diffhunk://#diff-1b800222c322c27580a65856212fc4fd9bf1128603cb0864b2e85f6f22b567c9L1-L9): Deleted the GitVersion configuration file.

### Data Service Updates:

* [`src/services/dataService.ts`](diffhunk://#diff-88b954161e6bd88b13449fc0f255973fee4902738d8b5e00609cc58fa3486936L106-R119): Added a new function `getRecipeMediaUrl` to fetch the media URL and updated the existing `getRecipeMedia` function to remove filtering by type.

### Handling Video URLs:

* [`src/helpers/videoHelpers.ts`](diffhunk://#diff-e01495ff3fac3a9fcec393e3615d9b6151a7fa440cdeffbbc29b2931969cd59aR1-R21): Added a new function `getThumbnail` to generate YouTube video thumbnails and refactored `prepareUrlForEmbed` to use the `getVideoId` helper function. [[1]](diffhunk://#diff-e01495ff3fac3a9fcec393e3615d9b6151a7fa440cdeffbbc29b2931969cd59aR1-R21) [[2]](diffhunk://#diff-e01495ff3fac3a9fcec393e3615d9b6151a7fa440cdeffbbc29b2931969cd59aL20-R33)

### Component Updates:

* [`src/components/RecipeCard.vue`](diffhunk://#diff-e9bb804036d87425a99118aa2be66b4716eeb18680907d57af9957414fb7e807L27-R28): Added a `data-testid` attribute to the recipe image for better testability.
* [`src/components/RecipeList.vue`](diffhunk://#diff-495c902f0da5ed9d37e80b9aeb65cb86881d538d21bfa939b3a557699427bc7aL6-R6): Updated to use `getRecipeMediaUrl` instead of `getRecipeMedia` for fetching recipe images. [[1]](diffhunk://#diff-495c902f0da5ed9d37e80b9aeb65cb86881d538d21bfa939b3a557699427bc7aL6-R6) [[2]](diffhunk://#diff-495c902f0da5ed9d37e80b9aeb65cb86881d538d21bfa939b3a557699427bc7aL165-R165)
* `src/pages/recipe/[id]/print.vue`: Updated to use `getRecipeMediaUrl` instead of `getRecipeMedia` for fetching recipe images. ([src/pages/recipe/[id]/print.vueL6-R6](diffhunk://#diff-890779b51e920e31bb640560a7e417d62b8fb1546068a37420aba01ead508234L6-R6), [src/pages/recipe/[id]/print.vueL60-R67](diffhunk://#diff-890779b51e920e31bb640560a7e417d62b8fb1546068a37420aba01ead508234L60-R67))

### Test Updates:

* [`tests/edit.spec.ts`](diffhunk://#diff-460838e915bd8104e6d52bfa9a7cede7fe12e03a389dc9a62f5867e65592aca2R102-R119): Added a new test to verify that video media shows the correct thumbnail.

### Issues
Closes #369 