### PR TITLE
Fixed bug with empty ingredient/steps

### DIFF
--- a/src/pages/recipe/[id]/index.vue
+++ b/src/pages/recipe/[id]/index.vue
@@ -397,10 +397,10 @@ async function shareOnline() {
     const model = {
       id: item.value.id,
       title: item.value.title,
-      ingredients: item.value.ingredients,
+      ingredients: item.value.ingredients.filter(ingredient => ingredient.trim() !== ""),
       notes: item.value.notes,
       source: item.value.source,
-      steps: item.value.steps,
+      steps: item.value.steps.filter(step => step.trim() !== ""),
       media: images.value.map(item => {
         return { "type": item.type, "url": item.url };
       }),


### PR DESCRIPTION
This pull request refines the `shareOnline` functionality in `src/pages/recipe/[id]/index.vue` to ensure that empty ingredients and steps are excluded from the shared model.

Key changes:

* `src/pages/recipe/[id]/index.vue`: Updated the `ingredients` and `steps` properties in the `model` object to filter out empty strings using `.filter()` with a `trim()` check. ([src/pages/recipe/[id]/index.vueL400-R403](diffhunk://#diff-e66b4651b56d6d50a747bb706db735545478b27ec3d9a9f13bf9587974cd1142L400-R403))