### PR TITLE
Added web insights

### DIFF
--- a/.github/workflows/azure-static-web-apps-delightful-flower-0c3edd710.yml
+++ b/.github/workflows/azure-static-web-apps-delightful-flower-0c3edd710.yml
@@ -57,7 +57,7 @@ jobs:
           api_location: "api" # Api source code path - optional
           output_location: "dist" # Built app content directory - optional
         env:
-          CI: true
+          VITE_CI: true
 
   test:
     needs: [build_and_deploy_job]

--- a/.github/workflows/azure-static-web-apps-delightful-flower-0c3edd710.yml
+++ b/.github/workflows/azure-static-web-apps-delightful-flower-0c3edd710.yml
@@ -56,6 +56,8 @@ jobs:
           app_location: "/" # App source code path
           api_location: "api" # Api source code path - optional
           output_location: "dist" # Built app content directory - optional
+        env:
+          CI: true
 
   test:
     needs: [build_and_deploy_job]
@@ -105,5 +107,6 @@ jobs:
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
+          app_location: "/"
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_DELIGHTFUL_FLOWER_0C3EDD710 }}
           action: "close"

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ let lastToDateTime: Date | null = null;
 let lastToPageViewId: string | null = null;
 
 router.afterEach((to, from) => {
-    if (import.meta.env.DEV) {
+    if (import.meta.env.DEV || import.meta.env.CI) {
         console.log('Navigated from:', from.fullPath, 'to:', to.fullPath);
         return;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ router.afterEach((to, from) => {
             .then((data) => {
                 lastToPageViewId = data || "";
             }).catch((error) => {
-                console.error('Error sending page view duration data:', error);
+                console.error('Error sending page view data:', error);
             })
     }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ let lastToDateTime: Date | null = null;
 let lastToPageViewId: string | null = null;
 
 router.afterEach((to, from) => {
-    if (import.meta.env.DEV || import.meta.env.CI) {
+    if (import.meta.env.VITE_DEV || import.meta.env.VITE_CI) {
         console.log('Navigated from:', from.fullPath, 'to:', to.fullPath);
         return;
     }

--- a/src/sharp-web-insights.ts
+++ b/src/sharp-web-insights.ts
@@ -1,0 +1,40 @@
+const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+export function sendPageViewData(url: string, referrer: string): Promise<string> {
+    const loadDateTime = new Date();
+    const pageViewData = {
+        url,
+        timeZone,
+        timestamp: loadDateTime.toISOString(),
+        referrer
+    };
+    return fetch('https://sharp-web-insights.azurewebsites.net/api/A5NuO0rxqm/pageview', {
+        method: 'POST',
+        body: JSON.stringify(pageViewData),
+        headers: { 'Content-Type': 'application/json' }
+    })
+        .then(response => {
+            return response.text();
+        });
+}
+
+
+export function sendPageViewDurationData(pageViewId: string, loadDateTime: Date): Promise<Response | null> {
+    if (pageViewId === "") {
+        return Promise.resolve(null);
+    }
+
+    const unloadDateTime = new Date();
+    const diffMilliseconds = Math.abs(unloadDateTime.getTime() - loadDateTime.getTime());
+    const diffSeconds = Math.round(diffMilliseconds / 1000);
+    const pageViewDurationData = {
+        id: pageViewId,
+        durationSeconds: diffSeconds,
+        timestamp: unloadDateTime.toISOString()
+    };
+    return fetch('https://sharp-web-insights.azurewebsites.net/api/A5NuO0rxqm/pageViewDuration', {
+        method: 'POST',
+        body: JSON.stringify(pageViewDurationData),
+        headers: { 'Content-Type': 'application/json' }
+    });
+}


### PR DESCRIPTION
This pull request introduces analytics tracking for page views and their durations in the application. The main changes add logic to record when users navigate between pages and send this data to an external web insights service. The new functionality is implemented in both the router setup and a dedicated service module.

**Analytics tracking integration:**

* Added a new module `src/sharp-web-insights.ts` that provides `sendPageViewData` and `sendPageViewDurationData` functions for sending page view and duration data to an external API, including time zone, timestamps, and referrer information.
* Imported the new analytics functions into `src/main.ts` to enable usage within the main application entry point.

**Router enhancements for tracking:**

* Implemented a `router.afterEach` hook in `src/main.ts` to send page view data on navigation and track the duration of the previous page view, including error handling and development mode logging.