### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Publish app
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/jlucaspains/sharp-cooking-web/security/code-scanning/3](https://github.com/jlucaspains/sharp-cooking-web/security/code-scanning/3)

To resolve this issue, add a `permissions` block with the least privilege required at the top/root level of the workflow YAML (before the `jobs:` section). This ensures all jobs default to the minimal permissions unless overridden. According to the recommendation and the CodeQL output, specify at least `contents: read` as a starting point. To implement, insert the following after the `name:` and before `on:` in `.github/workflows/release.yml`:

```yaml
permissions:
  contents: read
```

No new imports or definitions are needed, as this is a configuration edit to the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
