### PR TITLE
Fix youtube videos not loading in recipe gallery

### DIFF
--- a/src/components/ImageGallery.vue
+++ b/src/components/ImageGallery.vue
@@ -125,7 +125,11 @@ function close() {
                                     :class="{ 'm-auto max-w-full': true, 'lg:max-h-80 max-h-60': !isOpen, 'lg:max-h-full': isOpen }">
                             </a>
                             <iframe v-else title="Youtube video" class="youtube-player lg:h-80 h-60" type="text/html"
-                                width="100%" height="100%" allow="fullscreen;" allowFullScreen="allowfullscreen" frameborder="0"
+                                width="100%" height="100%" 
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                allowFullScreen="allowfullscreen" 
+                                frameborder="0"
+                                referrerpolicy="strict-origin-when-cross-origin"
                                 :src="image.url"></iframe>
                         </li>
                     </template>


### PR DESCRIPTION
This pull request updates the iframe configuration for embedded YouTube videos in the `ImageGallery.vue` component. The main change is the enhancement of iframe security and feature permissions.

**Embedded YouTube iframe improvements:**

* Expanded the `allow` attribute to include additional permissions for better compatibility and security, such as `accelerometer`, `autoplay`, `clipboard-write`, `encrypted-media`, `gyroscope`, `picture-in-picture`, and `web-share`.
* Added the `referrerpolicy="strict-origin-when-cross-origin"` attribute to improve privacy and security for embedded content.